### PR TITLE
Chore/Remove Errors::Associations::NotFound.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,17 +97,17 @@ Added Rails flash message support to HTML responses:
 - `Responses::Html::RedirectResponse`.
 - `Responses::Html::RenderResponse`.
 
-#### Results
+### Results
 
 Implemented `Cuprum::Rails::Result`, which includes a `#metadata` property for passing contextual data such as an authentication session or page configuration.
 
-#### Routes
+### Routes
 
 Route helpers not accept a wildcards hash for populating route wildcards, as an alternative to calling `routes.with_wildcards`.
 
 Member route methods now accept a primary key value as well as an entity, or allow the key to be passed as part of the wildcards.
 
-#### RSpec
+### RSpec
 
 Implemented contracts for Cuprum::Rails actions
 
@@ -127,7 +127,7 @@ Defined `Cuprum::Rails::RSpec::SerializersContracts`:
 
 Implemented `Cuprum::Rails::RSpec::Matchers::BeAResultMatcher`, which adds support for a `#metadata` property to the `be_a_result` matcher.
 
-#### Serializers
+### Serializers
 
 Implemented `Cuprum::Rails::Serializers::Context`.
 

--- a/lib/cuprum/rails/actions/middleware/associations/parent.rb
+++ b/lib/cuprum/rails/actions/middleware/associations/parent.rb
@@ -24,8 +24,9 @@ module Cuprum::Rails::Actions::Middleware::Associations
       @request    = request
       @resource   = resource
 
-      values = step { require_parent }
-      result = super
+      primary_key = step { query_keys }
+      values      = step { require_parent(primary_key: primary_key) }
+      result      = super
 
       return result unless result.success?
 
@@ -56,8 +57,8 @@ module Cuprum::Rails::Actions::Middleware::Associations
       failure(error)
     end
 
-    def require_parent
-      values = step { perform_query }
+    def require_parent(primary_key:)
+      values = step { perform_query(keys: primary_key) }
 
       values.is_a?(Array) ? values.first : values
     end

--- a/lib/cuprum/rails/actions/middleware/associations/query.rb
+++ b/lib/cuprum/rails/actions/middleware/associations/query.rb
@@ -109,8 +109,8 @@ module Cuprum::Rails::Actions::Middleware::Associations
       )
     end
 
-    def perform_query
-      keys = step { query_keys }
+    def perform_query(keys: nil)
+      keys ||= step { query_keys }
 
       if keys.is_a?(Array)
         query_command.call(keys: keys)

--- a/spec/cuprum/rails/actions/middleware/associations/parent_spec.rb
+++ b/spec/cuprum/rails/actions/middleware/associations/parent_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Cuprum::Rails::Actions::Middleware::Associations::Parent do
       let(:book_id) { (Book.order(:id).last&.id || -1) + 1 }
       let(:params)  { super().merge('book_id' => book_id) }
       let(:expected_error) do
-        Cuprum::Collections::Errors::Associations::NotFound.new(
+        Cuprum::Collections::Errors::NotFound.new(
           attribute_name:  'id',
           attribute_value: book_id,
           collection_name: 'book',


### PR DESCRIPTION
- Allow injecting query keys in Associations::Query.